### PR TITLE
Fixes for nvidia-ko-to-module-symvers

### DIFF
--- a/driver/linux/nvidia-ko-to-module-symvers
+++ b/driver/linux/nvidia-ko-to-module-symvers
@@ -16,7 +16,7 @@ symvers_fn="$2"
 
 touch "${symvers_fn}"
 for sym in "${syms[@]}"; do
-	crc="$(objdump -t "${nvidia_ko_fn}" | grep "__crc_${sym}" | awk '{print $1}')"
+	crc="$(objdump -t "${nvidia_ko_fn}" | grep "__crc_${sym}$" | awk '{print $1}')"
 	if [ -z "${crc}" ]; then
 		echo "Warning: Can't find symbol ${sym} in ${nvidia_ko_fn}; assuming CONFIG_MODVERSIONS=n so setting CRC=0"
 		crc=00000000

--- a/driver/linux/nvidia-ko-to-module-symvers
+++ b/driver/linux/nvidia-ko-to-module-symvers
@@ -14,13 +14,26 @@ syms+=(nvidia_p2p_dma_unmap_pages)
 nvidia_ko_fn="$1"
 symvers_fn="$2"
 
+# Get the offset to the CRC table
+crc_table_offset=$(objdump -h "${nvidia_ko_fn}" | grep __kcrctab | awk '{print $6}')
+
 touch "${symvers_fn}"
 for sym in "${syms[@]}"; do
-	crc="$(objdump -t "${nvidia_ko_fn}" | grep "__crc_${sym}$" | awk '{print $1}')"
+	# Find the symbol entry
+	entry=$(objdump -t "${nvidia_ko_fn}" | grep "__crc_${sym}$")
+	crc=$(echo "${entry}" | awk '{print $1}')
 	if [ -z "${crc}" ]; then
 		echo "Warning: Can't find symbol ${sym} in ${nvidia_ko_fn}; assuming CONFIG_MODVERSIONS=n so setting CRC=0"
 		crc=00000000
 	fi
+
+	# If the entry type is an offset into the CRC table, look up the value
+	crc_type=$(echo "${entry}" | awk '{print $3}')
+	if [ "${crc_type}" = "__kcrctab" ]; then
+		crc=$(dd if="${nvidia_ko_fn}" status=none bs=1 count=4 skip=$((0x${crc_table_offset} + 0x${crc})) | od -A n -t x4)
+		crc=00000000${crc:1}
+	fi
+
 	sed -i '/${sym}/d' "${symvers_fn}"
 	echo "0x${crc}	${sym}	${nvidia_ko_fn}	EXPORT_SYMBOL	" >> ${symvers_fn}
 done


### PR DESCRIPTION
Note that these changes were previously merged into the old `ntv2` repo, here: https://github.com/aja-video/ntv2/pull/34

1. Fix nvidia-ko-to-module-symvers pattern matching. The previously used pattern would hit partial matches, which could lead to errors if more than one symbol shared the same prefix.

2. Update nvidia-ko-to-module-symvers to support CRC table. CRC entries for symbols exported by kernel modules may be provided either by absolute values in the symbol table, or as offsets into the CRC table stored in a separate __kcrctab data section. This change adds support for the latter type of relative entry as it is needed to support RDMA with newer kernels (>= 5.19).