### PR TITLE
Add ajantv2 CMake package config

### DIFF
--- a/ajantv2/CMakeLists.txt
+++ b/ajantv2/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(ajantv2)
 
+include(CMakePackageConfigHelpers)
+
 if (CMAKE_CXX_STANDARD EQUAL 98)
     message(STATUS "ajantv2 building for C++98")
     remove_definitions(
@@ -35,6 +37,11 @@ set(TARGET_INCLUDE_DIRS
     ${LIBAJANTV2_DIR}/ajabase
     ${LIBAJANTV2_DIR}/ajantv2/includes
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+set(INSTALL_INCLUDE_DIRS
+    ${CMAKE_INSTALL_INCLUDEDIR}/libajantv2
+    ${CMAKE_INSTALL_INCLUDEDIR}/libajantv2/ajantv2/includes
 )
 
 # ajantv2
@@ -464,6 +471,9 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
         ${LIBAJANTV2_DIR}/ajabase/pnp/windows
         ${LIBAJANTV2_DIR}/ajabase/system/windows)
 
+    list(APPEND INSTALL_INCLUDE_DIRS
+        ${CMAKE_INSTALL_INCLUDEDIR}/libajantv2/ajantv2/src/win)
+
     set(AJABASE_HEADERS
         ${AJABASE_HEADERS}
         ${AJABASE_PNP_WIN_HEADERS}
@@ -489,6 +499,8 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         ${LIBAJANTV2_DIR}/ajantv2/src/lin
         ${LIBAJANTV2_DIR}/ajabase/pnp/linux
         ${LIBAJANTV2_DIR}/ajabase/system/linux)
+    list(APPEND INSTALL_INCLUDE_DIRS
+        ${CMAKE_INSTALL_INCLUDEDIR}/libajantv2/ajantv2/src/lin)
     list(APPEND AJABASE_HEADERS
         ${AJABASE_PNP_LIN_HEADERS}
         ${AJABASE_SYS_LIN_HEADERS})
@@ -541,6 +553,8 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         ${LIBAJANTV2_DIR}/ajabase/pnp/mac
         ${LIBAJANTV2_DIR}/ajabase/system/mac
         /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include)
+    list(APPEND INSTALL_INCLUDE_DIRS
+        ${CMAKE_INSTALL_INCLUDEDIR}/libajantv2/ajantv2/src/mac)
     list(APPEND AJABASE_HEADERS
         ${AJABASE_PNP_MAC_HEADERS}
         ${AJABASE_SYS_MAC_HEADERS})
@@ -615,7 +629,8 @@ if (NOT TARGET ${PROJECT_NAME})
 
     target_include_directories(${PROJECT_NAME} PRIVATE ${TARGET_INCLUDE_DIRS})
     target_include_directories(${PROJECT_NAME} INTERFACE
-        "$<BUILD_INTERFACE:${TARGET_INCLUDE_DIRS}>")
+        "$<BUILD_INTERFACE:${TARGET_INCLUDE_DIRS}>"
+        "$<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIRS}>")
     target_link_libraries(${PROJECT_NAME} PRIVATE ${TARGET_LINK_LIBS})
     target_link_libraries(${PROJECT_NAME} INTERFACE
         "$<BUILD_INTERFACE:${TARGET_LINK_LIBS}>")
@@ -698,11 +713,28 @@ if (AJA_INSTALL_MISC)
 endif()
 
 install(TARGETS ${PROJECT_NAME}
+    EXPORT          ajantv2-targets
     ARCHIVE         DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY         DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME         DESTINATION ${CMAKE_INSTALL_BINDIR}
     FRAMEWORK       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+set(AJANTV2_INSTALL_CMAKECONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/ajantv2)
+install(EXPORT ajantv2-targets
+    NAMESPACE AJA::
+    DESTINATION ${AJANTV2_INSTALL_CMAKECONFIGDIR})
+configure_package_config_file(ajantv2-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/ajantv2-config.cmake
+    INSTALL_DESTINATION ${AJANTV2_INSTALL_CMAKECONFIGDIR})
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/ajantv2-config-version.cmake
+    VERSION ${AJA_NTV2_VER_STR}
+    COMPATIBILITY SameMajorVersion)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/ajantv2-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/ajantv2-config-version.cmake
+    DESTINATION ${AJANTV2_INSTALL_CMAKECONFIGDIR})
 
 if (NOT AJANTV2_DISABLE_TESTS)
     add_subdirectory(test)

--- a/ajantv2/ajantv2-config.cmake.in
+++ b/ajantv2/ajantv2-config.cmake.in
@@ -1,0 +1,6 @@
+set(AJANTV2_VERSION x.y.z)
+
+@PACKAGE_INIT@
+
+get_filename_component(AJANTV2_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(${AJANTV2_CMAKE_DIR}/ajantv2-targets.cmake)


### PR DESCRIPTION
This adds CMake rules to output the ajantv2
config such that the ajantv2 library can be
built and linked against using the following:

  find_package(ajantv2 <version> REQUIRED)
  target_link_libraries(<target> AJA::ajantv2)