### PR TITLE
common.h: Add cstdint include for uint64_t

### DIFF
--- a/ajabase/common/common.h
+++ b/ajabase/common/common.h
@@ -14,6 +14,7 @@
 #endif
 
 #include "ajabase/common/export.h"
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This fixes a build issue with our yocto-based build for the NVIDIA IGX Orin Devkit.