### PR TITLE
Change CMake warning messsage to status to avoid unnecessary warning

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -82,7 +82,7 @@ if (NTV2_VERSION_BUILD)
     set(AJA_NTV2_SDK_BUILD_NUMBER ${NTV2_VERSION_BUILD})
 endif()
 if (NOT AJA_NTV2_SDK_BUILD_NUMBER)
-    message(WARNING "NTV2 build number not specified. Defaulting to 0.")
+    message(STATUS "NTV2 build number not specified. Defaulting to 0.")
     set(AJA_NTV2_SDK_BUILD_NUMBER "0")
 endif()
 


### PR DESCRIPTION
When building libajantv2 via CPM, CMake reports a warning when the build version is not set (default via CPM without setting a build version via environment variable). This PR modifies the warning to a status message to avoid reporting configuration warnings.