### PR TITLE
Fix RDMA for iGPU

### DIFF
--- a/driver/linux/Makefile
+++ b/driver/linux/Makefile
@@ -33,7 +33,7 @@ endif
 
 # try to find the nvidia p2p include file
 ifeq ($(NVIDIA_SRC_DIR),)
-	NVIDIA_SRC_DIR := $(shell find /usr/src/nvidia-* -name nv-p2p.h 2>/dev/null|head -1|xargs dirname 2>/dev/null)
+	NVIDIA_SRC_DIR := $(shell find /usr/src/nvidia* -name nv-p2p.h 2>/dev/null|head -1|xargs dirname 2>/dev/null)
 endif
 ifeq ($(NVIDIA_SRC_DIR),)
 	NVIDIA_SRC_DIR := $(shell find /usr/src/linux-* -name nv-p2p.h 2>/dev/null|head -1|xargs dirname 2>/dev/null)
@@ -52,20 +52,21 @@ endif
 
 # if doing rdma build
 ifdef NVIDIA_RDMA
+ifdef AJA_IGPU
+# configure for igpu to use the nvidia-p2p.ko module
+	EXTRA_CFLAGS += -DAJA_IGPU=1
+	NVIDIA_KO ?= $(shell find /lib/modules/$(KVERSION)/ -name 'nvidia-p2p.ko'|head -1)
+else
 	NVIDIA_KO ?= $(shell find /lib/modules/$(KVERSION)/ -name 'nvidia*.ko'|grep -P 'nvidia(_[0-9]+)?.ko'|head -1)
+endif
 ifeq ($(shell modinfo $(NVIDIA_KO) | grep license: | grep GPL),)
 	EXTRA_CFLAGS += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1 -DNVIDIA_PROPRIETARY=1
 else
 	EXTRA_CFLAGS += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1
 endif
-ifdef AJA_IGPU
-# configure for igpu
-	EXTRA_CFLAGS += -DAJA_IGPU=1
-else
 ifeq ($(NVIDIA_SYMVERS),)
 	NVIDIA_GEN_SYMVERS := ./nvidia-ko-to-module-symvers $(NVIDIA_KO) $(A_LINUX_DRIVER_PATH)/nvidia.symvers
 	NVIDIA_SYMVERS := $(A_LINUX_DRIVER_PATH)/nvidia.symvers
-endif
 endif
 endif
 
@@ -232,12 +233,8 @@ default: all
 	@echo linux distro flags: '$(DISTRO_INFO)'
 	@echo lib: $(LIB)
 ifdef NVIDIA_RDMA
-ifdef AJA_IGPU
-	$(MAKE) -C $(KDIR) M=$(A_LINUX_DRIVER_PATH) DRIVERDIR=$(A_LINUX_DRIVER_PATH) modules
-else
 	${NVIDIA_GEN_SYMVERS}
 	$(MAKE) -C $(KDIR) M=$(A_LINUX_DRIVER_PATH) DRIVERDIR=$(A_LINUX_DRIVER_PATH) modules KBUILD_EXTRA_SYMBOLS='$(NVIDIA_SYMVERS)'
-endif
 else
 	$(MAKE) -C $(KDIR) M=$(A_LINUX_DRIVER_PATH) DRIVERDIR=$(A_LINUX_DRIVER_PATH) modules
 endif

--- a/driver/linux/ntv2rdma.h
+++ b/driver/linux/ntv2rdma.h
@@ -11,24 +11,17 @@
 #ifdef AJA_RDMA
 #include <nv-p2p.h>
 
+typedef int (*rdma_free_page_table)(struct nvidia_p2p_page_table *page_table);
+
+#ifdef AJA_IGPU
+
 typedef int (*rdma_get_pages)(
-    uint64_t p2p_token, uint32_t va_space,
-#ifndef AJA_IGPU
-    uint64_t virtual_address, uint64_t length,
-#endif                              
+    uint64_t vaddr, uint64_t size,
     struct nvidia_p2p_page_table **page_table,
     void (*free_callback)(void *data), void *data);
 
 typedef int (*rdma_put_pages)(
-#ifndef AJA_IGPU
-    uint64_t p2p_token,
-    uint32_t va_space, uint64_t virtual_address,
-#endif    
     struct nvidia_p2p_page_table *page_table);
-
-typedef int (*rdma_free_page_table)(struct nvidia_p2p_page_table *page_table);
-
-#ifdef AJA_IGPU
 
 typedef int (*rdma_dma_map_pages)(
     struct device *dev,
@@ -40,6 +33,17 @@ typedef int (*rdma_dma_unmap_pages)(
     struct nvidia_p2p_dma_mapping *dma_mapping);
 
 #else
+
+typedef int (*rdma_get_pages)(
+    uint64_t p2p_token, uint32_t va_space,
+    uint64_t virtual_address, uint64_t length,
+    struct nvidia_p2p_page_table **page_table,
+    void (*free_callback)(void *data), void *data);
+
+typedef int (*rdma_put_pages)(
+    uint64_t p2p_token,
+    uint32_t va_space, uint64_t virtual_address,
+    struct nvidia_p2p_page_table *page_table);
 
 typedef int (*rdma_dma_map_pages)(
     struct pci_dev *peer,


### PR DESCRIPTION
The RDMA support for iGPU is now provided by the `nvidia-p2p.ko` module, and the symbols should be included in the same way that the symbols from `nvidia.ko` are included for the dGPU RDMA build.

This also fixes a function signature error with `rdma_get_pages` (and moves `rdma_put_pages` for consistency).

This was tested on:
- x86 system with Ubuntu 22.04 and open kernel drivers
- IGX devkit with iGPU and JetPack 6.0
- IGX devkit with dGPU and IGX-SW 1.0 (https://docs.nvidia.com/igx-orin/user-guide/latest/software-releases.html)