### PR TITLE
Replace cpuid based CPU detection with Win registry-based detection in aja_getcputype()

### DIFF
--- a/ajabase/system/windows/infoimpl.cpp
+++ b/ajabase/system/windows/infoimpl.cpp
@@ -369,25 +369,9 @@ aja_getosname()
 std::string
 aja_getcputype()
 {
-	// get CPU info
-	int CPUInfo[4] = {-1};
-	char CPUBrandString[0x40];
-	__cpuid(CPUInfo, 0x80000000);
-	unsigned int nExIds = CPUInfo[0];
-	memset(CPUBrandString, 0, sizeof(CPUBrandString));
-	for (unsigned int i=0x80000000; i<=nExIds; ++i)
-	{
-		// Get the information associated with each extended ID.
-		__cpuid(CPUInfo, i);
-		// Interpret CPU brand string.
-		if	(i == 0x80000002)
-			memcpy(CPUBrandString, CPUInfo, sizeof(CPUInfo));
-		else if	 (i == 0x80000003)
-			memcpy(CPUBrandString + 16, CPUInfo, sizeof(CPUInfo));
-		else if	 (i == 0x80000004)
-			memcpy(CPUBrandString + 32, CPUInfo, sizeof(CPUInfo));
-	}
-
+	std::string CPUBrandString = aja::read_registry_string(HKEY_LOCAL_MACHINE,
+		"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+		"ProcessorNameString");
 	return CPUBrandString;
 }
 


### PR DESCRIPTION
The `aja_getcputype()` function has been updated to retrieve the CPU brand string using the Windows registry instead of relying on the `__cpuid` instruction.
This approach improves compatibility across different architectures (especially for Windows on ARM systems) that do not support the `__cpuid` instruction, while still maintaining the ability to retrieve CPU type. 

The changes were tested on both x64 and ARM-based Windows machines, and the build was successful in both environments.