### PR TITLE
Fix nvidia_p2p_get_pages length alignment

### DIFF
--- a/driver/linux/ntv2rdma.c
+++ b/driver/linux/ntv2rdma.c
@@ -77,11 +77,7 @@ static int ntv2_rdma_get_pages(PDMA_PAGE_BUFFER pBuffer,
 	ULWord64 rdmaAddress = address & GPU_PAGE_MASK;
 	ULWord64 rdmaOffset = address & GPU_PAGE_OFFSET;
 	ULWord64 rdmaLen = size;
-#ifdef AJA_IGPU		
 	ULWord64 rdmaAlignedLen = (rdmaOffset + rdmaLen + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
-#else
-	ULWord64 rdmaAlignedLen = address + size - rdmaAddress;
-#endif		
 	struct nvidia_p2p_page_table* rdmaPage = NULL;
 	int ret = -1;
 


### PR DESCRIPTION
The length of RDMA buffers needs to be aligned to 64Kb pages. This has always been the case but the NVIDIA driver did not previously check for this alignment. The 560 NVIDIA drivers added this alignment check, so the caller now need to make sure the length is aligned to avoid errors.