### PR TITLE
linux_driver: Fix build with kernel 6.10 and newer

### DIFF
--- a/driver/linux/buildenv.h
+++ b/driver/linux/buildenv.h
@@ -19,6 +19,10 @@
 
 #include <linux/version.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0))
+	#define KERNEL_6_10_0_SERIAL_KFIFO
+#endif
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0))
 	#define KERNEL_6_5_0_GET_USER_PAGES
 #endif


### PR DESCRIPTION
circ_buf is not used anymore for serial IO and is replaced by kfifo.