### PR TITLE
fix: do not leak compiler options

### DIFF
--- a/ajantv2/CMakeLists.txt
+++ b/ajantv2/CMakeLists.txt
@@ -700,7 +700,7 @@ if (NOT TARGET ${PROJECT_NAME})
     set(_compiler_is_gnu_or_clang $<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>)
     set(_compile_options_win_debug /Od /RTC1 /W3)
     set(_compile_options_mac_lin_debug -O0 -Wall)
-    target_compile_options(${PROJECT_NAME} PUBLIC
+    target_compile_options(${PROJECT_NAME} PRIVATE
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<PLATFORM_ID:Windows>,${_compiler_id_c_or_cxx_msvc}>:/MP /Zm200>
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<PLATFORM_ID:Windows>,${_compiler_id_c_or_cxx_msvc},$<CONFIG:Release>>:/O2 /W3>
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<PLATFORM_ID:Windows>,${_compiler_id_c_or_cxx_msvc},$<CONFIG:RelWithDebInfo>>:${_compile_options_win_debug}>


### PR DESCRIPTION
Dependent targets do not necessarily need the compiler settings the AJA library uses. Like warning levels and others