### PR TITLE
fix: NTV2_POINTER can be deprecated

### DIFF
--- a/ajantv2/src/ntv2stream.cpp
+++ b/ajantv2/src/ntv2stream.cpp
@@ -77,7 +77,7 @@ ULWord CNTV2Card::StreamBufferQueue (const NTV2Channel inChannel,
 ULWord CNTV2Card::StreamBufferRelease (const NTV2Channel inChannel,
 										NTV2StreamBuffer& status)
 {
-	NTV2_POINTER buffer;
+	NTV2Buffer buffer;
 	if (!StreamBufferOps(inChannel, buffer, 0, NTV2_STREAM_BUFFER_RELEASE, status))
 		return NTV2_STREAM_STATUS_FAIL | NTV2_STREAM_STATUS_MESSAGE;
 	return status.mStatus;
@@ -87,7 +87,7 @@ ULWord CNTV2Card::StreamBufferStatus (const NTV2Channel inChannel,
 										ULWord64 bufferCookie,
 										NTV2StreamBuffer& status)
 {
-	NTV2_POINTER buffer;
+	NTV2Buffer buffer;
 	if (!StreamBufferOps(inChannel, buffer, bufferCookie, NTV2_STREAM_BUFFER_STATUS, status))
 		return NTV2_STREAM_STATUS_FAIL | NTV2_STREAM_STATUS_MESSAGE;
 	return status.mStatus;


### PR DESCRIPTION
Enabling all deprecation defines casues the library to fail to compile