### PR TITLE
Added move semantics to AJAAncillaryList.

### DIFF
--- a/ajaanc/includes/ancillarylist.h
+++ b/ajaanc/includes/ancillarylist.h
@@ -176,6 +176,9 @@ public:	//	INSTANCE METHODS
 	///@{
 											AJAAncillaryList ();			///< @brief	Instantiate and initialize with a default set of values.
 	inline									AJAAncillaryList (const AJAAncillaryList & inRHS)	{*this = inRHS;}	///< @brief	My copy constructor.
+#if defined(AJA_USE_CPLUSPLUS11)
+											AJAAncillaryList (AJAAncillaryList && inRHS);	///< @brief Move-construct constructor.
+#endif
 	virtual									~AJAAncillaryList ();			///< @brief	My destructor.
 
 	/**
@@ -185,6 +188,15 @@ public:	//	INSTANCE METHODS
 	**/
 	virtual AJAAncillaryList &				operator = (const AJAAncillaryList & inRHS);
 	///@}
+
+#if defined(AJA_USE_CPLUSPLUS11)
+	/**
+		@brief		Move-assignment operator -- moves contents from the right-hand-side to my contents, replacing my contents, and resets the right-hand-side.
+		@param[in]	inRHS	The list of packets to be move into me.
+		@return		An r-value reference to myself.
+	**/
+	virtual AJAAncillaryList &				operator = (AJAAncillaryList && inRHS);	///< @brief Move-construct constructor.
+#endif
 
 
 	/**

--- a/ajaanc/src/ancillarylist.cpp
+++ b/ajaanc/src/ancillarylist.cpp
@@ -17,6 +17,9 @@
 #if defined(AJAANCLISTIMPL_VECTOR)
 	#include <algorithm>
 #endif
+#if defined(AJA_USE_CPLUSPLUS11)
+	#include <utility>		//	For std::move
+#endif
 
 using namespace std;
 
@@ -163,6 +166,21 @@ AJAAncillaryList::AJAAncillaryList ()
 	SetAnalogAncillaryDataTypeForLine (285, AJAAncDataType_Cea608_Line21);
 }
 
+#if defined(AJA_USE_CPLUSPLUS11)
+AJAAncillaryList::AJAAncillaryList(AJAAncillaryList && inRHS)
+	:	m_ancList(std::move(inRHS.m_ancList)),
+		m_rcvMultiRTP(inRHS.m_rcvMultiRTP),		//	By default, handle receiving multiple RTP packets
+		m_xmitMultiRTP(inRHS.m_xmitMultiRTP),	//	By default, transmit single RTP packet
+		m_ignoreCS(inRHS.m_ignoreCS)
+{
+	// Reset RHS.
+	inRHS.m_rcvMultiRTP = true;
+	inRHS.m_xmitMultiRTP = false;
+	inRHS.m_ignoreCS = false;
+	// inRHS.m_ancList - already moved/reset.
+}
+#endif
+
 
 AJAAncillaryList::~AJAAncillaryList ()
 {
@@ -185,6 +203,26 @@ AJAAncillaryList & AJAAncillaryList::operator = (const AJAAncillaryList & inRHS)
 	return *this;
 }
 
+#if defined(AJA_USE_CPLUSPLUS11)
+AJAAncillaryList & AJAAncillaryList::operator = (AJAAncillaryList && inRHS)
+{
+	if (this != &inRHS)
+	{
+		m_xmitMultiRTP = inRHS.m_xmitMultiRTP;
+		inRHS.m_xmitMultiRTP = false;
+
+		m_rcvMultiRTP = inRHS.m_rcvMultiRTP;			
+		inRHS.m_rcvMultiRTP	= true;
+		
+		m_ignoreCS = inRHS.m_ignoreCS;
+		inRHS.m_ignoreCS = false;
+		
+		Clear(); // Clear down any packets currently being held in 'this'
+		m_ancList = std::move(inRHS.m_ancList);
+	}
+	return *this;
+}
+#endif
 
 AJAAncillaryData * AJAAncillaryList::GetAncillaryDataAtIndex (const uint32_t inIndex) const
 {


### PR DESCRIPTION
The AJAAncillaryList encapsulates the following data types:

```
	AJAAncillaryDataList	m_ancList;		///< @brief	My packet list
	bool					m_rcvMultiRTP;	///< @brief	True: Rcv 1 RTP pkt per Anc pkt;  False: Rcv 1 RTP pkt for all Anc pkts
	bool					m_xmitMultiRTP;	///< @brief	True: Xmit 1 RTP pkt per Anc pkt;  False: Xmit 1 RTP pkt for all Anc pkts
	bool					m_ignoreCS;		///< @brief	True: ignore checksum errors;  False: don't ignore CS errors
```

...and AJAAncillaryDataList is a typedef for:

```
typedef std::vector <AJAAncillaryData*>			AJAAncillaryDataList;
```

which means the underlying types already have support for move semantics with a C++11 compiler. 

I have the following function in my code:

```
AJAAncillaryList content_processor_aja_sdi_output::get_vanc_data_to_insert(...)
{
    AJAAncillaryList pkts;
    // ...
    return pkts;
}
```

Every time this function is called, instead of moving the packets, the packets get copied (allocation/deallocation per ancillary type) when they can merely be moved.

Changes tested within a linux environment - not tested on Windows. Need to be careful of introducing memory leaks, but I think I've covered all bases.