### PR TITLE
Improve random access for 'GetAncillaryDataAtIndex'

### DIFF
--- a/ajaanc/src/ancillarylist.cpp
+++ b/ajaanc/src/ancillarylist.cpp
@@ -190,13 +190,17 @@ AJAAncillaryData * AJAAncillaryList::GetAncillaryDataAtIndex (const uint32_t inI
 {
 	AJAAncillaryData *	pAncData(AJA_NULL);
 
-	if (!m_ancList.empty()	&&	inIndex < m_ancList.size())
+	if (inIndex < m_ancList.size())
 	{
+#if defined(AJAANCLISTIMPL_VECTOR)
+		pAncData = m_ancList[inIndex]; // Yay! std::vector has random access.
+#else
 		AJAAncDataListConstIter it	(m_ancList.begin());
 
 		for (uint32_t i(0);	 i < inIndex;  i++) //	Dang, std::list has no random access
 			++it;
 		pAncData = *it;
+#endif
 	}
 	return pAncData;
 }


### PR DESCRIPTION
When the underlying container type for AJAAncillaryDataList is an std::vector (default), the code assumes there is no random access.  This is because before 16.3, the underlying container type used to hold the data was an std::list.

To access data at a given index, the code will iterate through each item to reach item at position 'n' - see GetAncillaryDataAtIndex. This change improves random access when the underlying container is an std::vector<>.