### PR TITLE
[fix] enable linux driver building for 5.14.0-503.14.1.el9_5

### DIFF
--- a/driver/linux/buildenv.h
+++ b/driver/linux/buildenv.h
@@ -71,6 +71,11 @@
 		#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)) && DISTRO_KERNEL_PKG_MAJ >= 449)
 			#define KERNEL_6_3_0_VM_FLAGS
 		#endif
+
+		// This change was back-ported from kernel 6.3.0 for kernel 5.14.0-503
+		#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)) && DISTRO_KERNEL_PKG_MAJ >= 503)
+			#define KERNEL_6_3_0_VM_FLAGS
+		#endif
 	#endif
 #endif
 


### PR DESCRIPTION
Rocky 9.5 was released with new kernel package version. This version back-ports changes from kernel-6.3.0. This hotfix enables building libajantv2 linux drivers.