### PR TITLE
Fix CRP188 equal operator

### DIFF
--- a/ajantv2/includes/ntv2rp188.h
+++ b/ajantv2/includes/ntv2rp188.h
@@ -64,7 +64,7 @@ public:
 						CRP188 (ULWord frames, const TimecodeFormat tcFormat = kTCFormat30fps);
 	virtual				~CRP188();
 	void				Init ();
-	bool				operator==( const CRP188& s);
+	bool				operator==( const CRP188& s) const;
 
 	// Setters
 	void				SetRP188 (ULWord ulFrms, ULWord ulSecs, ULWord ulMins, ULWord ulHrs,
@@ -142,7 +142,7 @@ public:
 	bool				BurnTC (char *pBaseVideoAddress, int rowBytes, TimecodeBurnMode burnMode, int64_t frameCount = kDefaultFrameCount, bool bDisplay60_50fpsAs30_25 = false);
 	void				CopyDigit (char *pDigit, int digitWidth, int digitHeight, char *pFrameBuff, int fbRowBytes);
 	std::string			GetTimeCodeString(bool bDisplay60_50fpsAs30_25 = false);
-	
+
 private:
 	void				ConvertTcStrToVal (void);	// converts _sHMSF to _ulVal
 	void				ConvertTcStrToReg (void);	// converts _sHMSF to _rp188

--- a/ajantv2/src/ntv2rp188.cpp
+++ b/ajantv2/src/ntv2rp188.cpp
@@ -54,7 +54,7 @@ static const char CharMap [kMaxTCChars] [kDigitDotHeight] [kDigitDotWidth]	=
 	{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	},
-	
+
 // '1'
 	{
 	{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -425,7 +425,7 @@ void CRP188::Init()
 }
 
 
-bool CRP188::operator==( const CRP188& s)
+bool CRP188::operator==( const CRP188& s) const
 {
 	bool bResult = true;
 
@@ -2064,7 +2064,7 @@ string CRP188::GetTimeCodeString(bool bDisplay60_50fpsAs30_25)
 			}
 		}
 	}
-	
+
 	// if there is a "trailing character" (sometimes used for Field ID), do it now
 	if (trailingChar >= 0 && trailingChar < kMaxTCChars)
 	{


### PR DESCRIPTION
CRP:188::operator== should be const. 
MSVC complains when trying to do something like:

```
CRP188 r0(0);
CRP188 r1(0);
bool b = r0 == r1;
```

> error C2666: 'CRP188::operator ==': overloaded functions have similar conversions
> ajantv2\includes\ntv2rp188.h(67): note: could be 'bool CRP188::operator ==(const CRP188 &)'
> ajantv2\includes\ntv2rp188.h(67): note: or 'bool CRP188::operator ==(const CRP188 &)' [synthesized expression 'y == x']
> note: while trying to match the argument list '(CRP188, CRP188)'