### PR TITLE
Properly make CNTV2DeviceScanner::GetDeviceInfoList a class method

### DIFF
--- a/ajantv2/src/ntv2devicescanner.cpp
+++ b/ajantv2/src/ntv2devicescanner.cpp
@@ -117,7 +117,7 @@ CNTV2DeviceScanner::CNTV2DeviceScanner (const bool inScanNow)
 		}
 	#endif	//	!defined(NTV2_DEPRECATE_16_3)
 
-NTV2DeviceInfoList	GetDeviceInfoList (void)
+NTV2DeviceInfoList	CNTV2DeviceScanner::GetDeviceInfoList (void)
 {
 	AJAAutoLock tmpLock(&sDevInfoListLock);
 	return sDevInfoList;


### PR DESCRIPTION
In the header file, this is a static member of the class, but in the implementation cpp it's just a free function.

I don't really understand how this compiles for anyone as is, but given this function is deprecated anyway I'm not too uptight about fixing it - this is an upstreamed version of the patch I'm using in nixpkgs for libajantv2 since it doesn't build there without, possibly since we have stricter-than-standard build flags and most likely a newer compiler toolchain.